### PR TITLE
Fix indirect access to properties for compatibility with PHP 7

### DIFF
--- a/lib/Doctrine/Collection.php
+++ b/lib/Doctrine/Collection.php
@@ -460,7 +460,7 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
             $relations = $this->relation['table']->getRelations();
             foreach ($relations as $relation) {
                 if ($this->relation['class'] == $relation['localTable']->getOption('name') && $relation->getLocal() == $this->relation->getForeignFieldName()) {
-                    $record->$relation['alias'] = $this->reference;
+                    $record->{$relation['alias']} = $this->reference;
                     break;
                 }
             }

--- a/lib/Doctrine/Query/Abstract.php
+++ b/lib/Doctrine/Query/Abstract.php
@@ -1118,8 +1118,8 @@ abstract class Doctrine_Query_Abstract
                 $params = array('component' => $component, 'alias' => $alias);
                 $event = new Doctrine_Event($record, $callback['const'], $this, $params);
 
-                $record->$callback['callback']($event);
-                $table->getRecordListener()->$callback['callback']($event);
+                $record->{$callback['callback']}($event);
+                $table->getRecordListener()->{$callback['callback']}($event);
             }
         }
 


### PR DESCRIPTION
Fix indirect access to properties for compatibility with PHP 7.0 (and backwards compatible with 5.x)

See http://php.net/manual/en/migration70.incompatible.php#migration70.incompatible.variable-handling.indirect