### PR TITLE
Refactor preg_replace() with /e modifier to preg_replace_callback()

### DIFF
--- a/lib/Doctrine/Adapter/Statement/Oracle.php
+++ b/lib/Doctrine/Adapter/Statement/Oracle.php
@@ -583,7 +583,7 @@ class Doctrine_Adapter_Statement_Oracle implements Doctrine_Adapter_Statement_In
         }
         $bind_index = 1;
         // Replace ? bind-placeholders with :oci_b_var_ variables
-        $query = preg_replace("/(\?)/e", '":oci_b_var_". $bind_index++' , $query);
+        $query = preg_replace_callback("/(\?)/", function () use (&$bind_index) { return ":oci_b_var_" . $bind_index++; }, $query);
 
         $this->statement =  @oci_parse($this->connection, $query);
 


### PR DESCRIPTION
`preg_replace()` with `/e` modifier was deprecated in PHP 5.5 and removed in PHP 7.

It is still used in [lib/Doctrine/Adapter/Statement/Oracle.php](/punkave/doctrine1/blob/3e1cf8c776/lib/Doctrine/Adapter/Statement/Oracle.php#L586) and lib/Doctrine/Connection/Mssql.php ([1](/punkave/doctrine1/blob/3e1cf8c776/lib/Doctrine/Connection/Mssql.php#L264), [2](/punkave/doctrine1/blob/3e1cf8c776/lib/Doctrine/Connection/Mssql.php#L409)).

This replaces its usages with equivalent functionality using `preg_replace_callback()`.