### PR TITLE
Fix PHP 7.4 warning

### DIFF
--- a/lib/Doctrine/Query/Tokenizer.php
+++ b/lib/Doctrine/Query/Tokenizer.php
@@ -93,7 +93,7 @@ class Doctrine_Query_Tokenizer
                 break;
             
                 case 'by':
-                    continue;
+                break;
             
                 default:
                     if ( ! isset($p)) {


### PR DESCRIPTION
Fixes the following warning:
```
PHP Warning:  "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"?
```
This is the same fix that FriendsOfSymfony1/doctrine1 applied in https://github.com/FriendsOfSymfony1/doctrine1/commit/9feebcbcc66e82299f37763a9152a170cca474dc