### PR TITLE
Another PHP 7.4 warning fixed

### DIFF
--- a/lib/Doctrine/RawSql.php
+++ b/lib/Doctrine/RawSql.php
@@ -161,7 +161,7 @@ class Doctrine_RawSql extends Doctrine_Query_Abstract
                     }
                     break;
                 case 'by':
-                    continue;
+                    break;
                 default:
                     //not a keyword so we add it to the previous type.
                     if ( ! isset($parts[$type][0])) {


### PR DESCRIPTION
Sorry - doing these fixes through GitHub's web UI created two separate branches.

Taken from https://github.com/FriendsOfSymfony1/doctrine1/commit/9feebcbcc66e82299f37763a9152a170cca474dc